### PR TITLE
Suggestions to improve download error checking  ... not PR

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,6 +34,6 @@ Imports:
     stringr,
     tibble,
     tidyr,
-    utils
-    
+    utils,
+		httr    
   

--- a/R/collect.R
+++ b/R/collect.R
@@ -55,7 +55,23 @@ ppp_collect = function(version=NULL) {
   unlink(temp)
   cat('Unzip complete.\n')
 
-  # Call NAICS downloader
+# ==============
+#   SUGGESTION, using httr::GET plus a bit of error checking
+begin <- proc.time()
+r  <- httr::GET(url_dl)  %>% httr::stop_for_status()
+end  <- proc.time() - begin
+cat ("Download time ", end[3], "\n")
+
+# if TRUE, returns nothing
+testthat::expect_identical(httr::http_type(r), "application/zip")
+
+# CONTINUE, as before, or uncommnt these lines 
+# make_dir("jim_data")
+# writeBin(httr::content(r, "raw"), "jim.zip")
+# unzip("jim.zip", exdir = here::here("jim_data"), overwrite=T)
+# ==============   END SUGGESTION  =========
+
+# Call NAICS downloader
   naics_collect()
 
 }


### PR DESCRIPTION
Beginning with line "SUGGESTIONS",  could you take a look at this alternative code to download PPP files:
*  Use httr::GET with stop_for_status() check
*   Use testthat:expect_:identical() to check content is indeed of form  .zip


Just your comments would be great.
If you like it,  I can do real PR.


@kbmorales 
